### PR TITLE
fix memory leaks and segfault

### DIFF
--- a/CMS-BWT-functions.cpp
+++ b/CMS-BWT-functions.cpp
@@ -265,6 +265,7 @@ void lzInitialize(char *refFileName, char *collFileName, uint64_t prefixLength) 
          }
       }
       //x[n] = 0;
+      delete[] firstChar;
    }
    else{
       std::cerr << "Reference file is empty!\n";
@@ -325,7 +326,8 @@ void lzInitialize(char *refFileName, char *collFileName, uint64_t prefixLength) 
    _SA = sa;
    _ISA = new uint32_t[_n];
    _PLCP = new int32_t[_n];
-   _LCP = new int32_t[_n];
+   _LCP = new int32_t[_n + 1];
+   _LCP[_n] = -1;
    t01 = std::chrono::high_resolution_clock::now();
    constructISA(_SA,_ISA,_n);
    t02 = std::chrono::high_resolution_clock::now();
@@ -1330,6 +1332,7 @@ int lzFactorize(Args arg, char *collFileName) {
          }
       }
    }
+
    inHeads.close();
    std::remove("headsSA.txt");
    std::vector<Match>().swap(phrases);
@@ -1619,6 +1622,9 @@ int lzFactorize(Args arg, char *collFileName) {
       streamOutfile.write((char*)&prevChar, sizeof(uint8_t));
       streamOutfile.close();
    }
+
+   delete[] bucketsForExpandedBWT;
+   delete[] counterSmallerThanHead;
    
    //fclose(f);
    std::cerr << "Computed final BWT\n";
@@ -3064,6 +3070,8 @@ int lzFactorizeMemorySaving(Args arg, char *collFileName) {
    std::cerr << "Computed final BWT\n";
    t2 = std::chrono::high_resolution_clock::now();
    std::cerr << "Computing final BWT took: " << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count() << " ms\n";
+   delete[] bucketsForExpandedBWT;
+   delete[] counterSmallerThanHead;
    delete[] BWTheads;
    //print BWT_collection
    //std::cerr << "BWT_collection: ";

--- a/main.cpp
+++ b/main.cpp
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
 
     std::chrono::high_resolution_clock::time_point t1 = std::chrono::high_resolution_clock::now();
     std::ofstream errorFile(arg.outname+".log");
-    std::cerr.rdbuf(errorFile.rdbuf());
+    auto cerr_buf = std::cerr.rdbuf(errorFile.rdbuf());
     switch(arg.memory_saving) {
         case 0:
             std::cout << "==== CMS-BWT" << std::endl;
@@ -130,6 +130,12 @@ int main(int argc, char **argv) {
     }
     std::chrono::high_resolution_clock::time_point t2 = std::chrono::high_resolution_clock::now();
     std::cout << "==== Time elapsed: " << std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count() << " ms" << std::endl;
+
+    std::cerr.rdbuf(cerr_buf);
+    errorFile.close();
+
+    delete[] refFileName;
+    free(filename);
 
     return 0;
 }

--- a/predecessor.h
+++ b/predecessor.h
@@ -115,6 +115,8 @@ struct predecessor2{
 	uint32_t mask;
 	uint8_t shift;
 	~predecessor2(){
+		for (auto p : sampledPredArray)
+			delete[] p;
 		std::vector<predEle2 *>().swap(sampledPredArray);
 		std::vector<uint32_t>().swap(docSizes);
 	}


### PR DESCRIPTION
There are several memory leaks where memory for arrays is allocated but never freed.
Also, the `LCP`-array is too small at one point (it is accessed at `SA[i]+1` which may give `n` i.e. the size of the array).
Thirdly, the redirecting of `std::cerr` to a file sometimes caused problems on destruction when flushing the buffer. Resetting `std::cerr` and closing the file fixes that.
With the changes, GCC's address sanitizer doesn't find any more issues during my tests.